### PR TITLE
Adjust CI to differentiate obolib tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,12 +1,13 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
   pull_request:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 7 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
@@ -19,11 +20,6 @@ defaults:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    env:
-      NO_ET: 1
-      DANDI_ALLOW_LOCALHOST_URLS: "1"
-      DANDI_PAGINATION_DISABLE_FALLBACK: "1"
-      DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -32,13 +28,14 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python:
-          - 3.9
+          - 3.9  # Reaching EOL in October 2025
           - '3.10'  # Needs quotes so YAML doesn't think it's 3.1
           - '3.11'
           - '3.12'
           - '3.13'
         mode:
           - normal
+          - obolibrary-only
         include:
           - os: ubuntu-latest
             python: 3.9
@@ -97,10 +94,15 @@ jobs:
       if: github.event_name == 'schedule'
       run: echo PYTEST_ADDOPTS=--scheduled >> "$GITHUB_ENV"
 
-    - name: Run all tests
+    - name: Run all tests except those involving live services
       if: matrix.mode != 'dandi-api'
       run: |
-        python -m pytest -s -v --cov=dandi --cov-report=xml dandi
+        python -m pytest -s -v -m "not obolibrary" --cov=dandi --cov-report=xml dandi
+
+    - name: Run only tests related to obolibrary
+      if: matrix.mode == 'obolibrary-only'
+      run: |
+        python -m pytest -s -v -m obolibrary dandi
 
     - name: Smoke test example code in docs
       if: matrix.mode != 'dandi-api' && github.event_name == 'schedule'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,11 @@ defaults:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    env:
+      NO_ET: 1
+      DANDI_ALLOW_LOCALHOST_URLS: "1"
+      DANDI_PAGINATION_DISABLE_FALLBACK: "1"
+      DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -99,7 +99,7 @@ jobs:
       if: github.event_name == 'schedule'
       run: echo PYTEST_ADDOPTS=--scheduled >> "$GITHUB_ENV"
 
-    - name: Run all tests except those involving live services
+    - name: Run all tests except those involving obolibrary
       if: matrix.mode != 'dandi-api'
       run: |
         python -m pytest -s -v -m "not obolibrary" --cov=dandi --cov-report=xml dandi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '0 6 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}

--- a/tox.ini
+++ b/tox.ini
@@ -42,10 +42,11 @@ changedir = docs
 commands = sphinx-build -E -W -b html source build
 
 [pytest]
-addopts = --tb=short --durations=10 --timeout=300
+addopts = --tb=short --durations=10
 markers =
     integration
     obolibrary
+    flaky
 filterwarnings =
     error
     ignore:No cached namespaces found .*:UserWarning

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ changedir = docs
 commands = sphinx-build -E -W -b html source build
 
 [pytest]
-addopts = --tb=short --durations=10
+addopts = --tb=short --durations=10 --timeout=300
 markers =
     integration
     obolibrary


### PR DESCRIPTION
Fixes #1639 by specifying only to run obolibrary related tests on separate matrix while suppressing these during normal run

This isn't all network tests, but obolib is the main offender so starting with this for now